### PR TITLE
Fix TypeScript language server dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "^24.5.2",
-        "typescript-language-server": "^5.3.3"
+        "typescript-language-server": "^5.0.0"
       },
       "devDependencies": {
         "typescript": "^5.9.2"
@@ -42,18 +42,23 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-language-server": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-5.0.0.tgz",
+      "integrity": "sha512-Glr+4Ss9g6AupBPj3tnk3mrlSH1ROS2Zmr5h0Vmy3DA+MVq+5qq4tv4+SogB8VsEZ13Z9xU01zm54MMyI7Gdzw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "typescript-language-server": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "license": "MIT"
-    },
-    "node_modules/typescript-language-server": {
-      "version": "5.3.3",
-      "license": "MIT",
-      "bin": {
-        "typescript-language-server": "lib/cli.js"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "dependencies": {
     "@types/node": "^24.5.2",
-    "typescript-language-server": "^5.3.3"
+    "typescript-language-server": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- update the typescript-language-server dependency to the latest published 5.0.0 release
- regenerate the lockfile to pull in the corresponding package metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4c9975a60833097b03d579180ce51