### PR TITLE
Improve PolyClient lifecycle and adapter synchronization

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -84,12 +84,20 @@ export type LanguageRegistrationContext = {
   listDocuments(): TextDocument[];
   getRegisteredLanguages(): string[];
   notifyClient: NotifyClient;
+  registerDisposable(dispose: () => void | Promise<void>): void;
 };
 
 export type LanguageHandlers = {
   initialize?: (context: LanguageRegistrationContext) => MaybePromise<unknown>;
   shutdown?: () => MaybePromise<void>;
   openDocument?: (params: { uri: string; languageId: string; text: string; version: number }) => MaybePromise<void>;
+  updateDocument?: (params: {
+    uri: string;
+    languageId: string;
+    version: number;
+    text: string;
+    changes: DocumentChange[];
+  }) => MaybePromise<void>;
   closeDocument?: (params: { uri: string }) => MaybePromise<void>;
   getCompletions?: (params: unknown, context: RequestContext) => MaybePromise<unknown>;
   getHover?: (params: unknown, context: RequestContext) => MaybePromise<unknown>;
@@ -119,7 +127,7 @@ export type LanguageAdapter = {
 export type RegisteredLanguage = {
   languageId: string;
   displayName: string;
-  state: string;
+  state: 'registering' | 'initializing' | 'ready' | 'failed' | 'disposed';
   capabilities: Record<string, unknown>;
   registeredAt: Date;
 };
@@ -151,5 +159,5 @@ export interface PolyClient {
   onDiagnostics(uri: string, listener: Listener<DiagnosticsEvent>): Disposable;
   onWorkspaceEvent(kind: string, listener: Listener<WorkspaceEvent>): Disposable;
   applyWorkspaceEdit(edit: WorkspaceEdit): { applied: boolean; failures: { uri: string; reason: string }[] };
-  dispose(): void;
+  dispose(): MaybePromise<void>;
 }

--- a/src/utils/uri.ts
+++ b/src/utils/uri.ts
@@ -1,8 +1,43 @@
+import path from 'path';
+import { URL } from 'url';
 import { PolyClientError } from '../errors';
 
+const WINDOWS_DRIVE_REGEX = /^([a-zA-Z]):[\\/]/;
+
+function ensureFileUriFromPath(input: string): string {
+  const absolute = path.resolve(input);
+  const normalizedPath = absolute.replace(/\\/g, '/');
+  return `file://${normalizedPath.startsWith('/') ? '' : '/'}${encodeURI(normalizedPath)}`;
+}
+
 export function normalizeUri(uri: string | undefined | null): string {
-  if (typeof uri !== 'string' || uri.length === 0) {
+  if (typeof uri !== 'string' || uri.trim().length === 0) {
     throw new PolyClientError('INVALID_URI', 'Document uri must be a non-empty string.');
   }
-  return uri;
+
+  const trimmed = uri.trim();
+
+  try {
+    if (WINDOWS_DRIVE_REGEX.test(trimmed)) {
+      return ensureFileUriFromPath(trimmed);
+    }
+
+    if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed)) {
+      return ensureFileUriFromPath(trimmed);
+    }
+
+    const parsed = new URL(trimmed);
+    if (parsed.protocol === 'file:') {
+      let pathname = parsed.pathname.replace(/\\/g, '/');
+      const match = pathname.match(/^\/([a-zA-Z]):/);
+      if (match) {
+        pathname = `/${match[1].toUpperCase()}:${pathname.slice(3)}`;
+      }
+      parsed.pathname = pathname;
+      parsed.hash = '';
+    }
+    return parsed.toString();
+  } catch (error) {
+    throw new PolyClientError('INVALID_URI', `Invalid document uri: ${trimmed}`);
+  }
 }

--- a/tests/typescript.demo.test.js
+++ b/tests/typescript.demo.test.js
@@ -19,10 +19,10 @@ const tsWorkspaceFolder = path.join(projectRoot, 'examples', 'ts-demo');
 const tsExamplePath = path.join(tsWorkspaceFolder, 'src', 'index.ts');
 const URI = `file://${tsExamplePath}`;
 
-function createTypeScriptHarness() {
+async function createTypeScriptHarness() {
   const client = createPolyClient({ workspaceFolders: [tsWorkspaceFolder] });
   const adapter = createTypeScriptAdapter();
-  registerLanguage(client, adapter);
+  await registerLanguage(client, adapter);
   const source = fs.readFileSync(tsExamplePath, 'utf8');
   client.openDocument({ uri: URI, languageId: 'typescript', text: source, version: 1 });
   return {
@@ -33,11 +33,11 @@ function createTypeScriptHarness() {
 }
 
 async function withTypeScriptHarness(run) {
-  const harness = createTypeScriptHarness();
+  const harness = await createTypeScriptHarness();
   try {
     await run(harness);
   } finally {
-    harness.dispose();
+    await harness.dispose();
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
+    "types": ["node"]
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
## Summary
- refactor PolyClient lifecycle to track registration state, normalize URIs, and forward document changes and workspace edits to adapters
- expose document-change notifications to adapters and add registerDisposable support in the registration context while enhancing URI normalization
- update TypeScript and Go adapters to publish diagnostics, send didChange events, and cleanly shutdown; expand tests to cover synchronization and asynchronous disposal
- tighten gopls stream parsing to respect byte-length framing and suppress expected shutdown noise from the TypeScript adapter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4cbd414c08330a161d3dd95bee65d