### PR TITLE
Align client with LSP 3.17 server requests and workspace edits

### DIFF
--- a/src/adapters/typescript.ts
+++ b/src/adapters/typescript.ts
@@ -6,6 +6,10 @@ import {
   LanguageAdapter,
   LanguageRegistrationContext,
   LanguageHandlers,
+  SaveOptions,
+  TextDocumentSyncKind,
+  TextDocumentSyncOptions,
+  WorkspaceEdit,
 } from '../types';
 import { JsonRpcConnection } from '../utils/jsonRpc';
 
@@ -31,6 +35,67 @@ type InitializationState = {
 
 const DEFAULT_REQUEST_TIMEOUT = 15000;
 
+type ResolvedTextDocumentSync = {
+  openClose: boolean;
+  change: TextDocumentSyncKind;
+  willSave: boolean;
+  willSaveWaitUntil: boolean;
+  save?: boolean | SaveOptions;
+};
+
+const TEXT_DOCUMENT_SYNC_KIND: Record<'None' | 'Full' | 'Incremental', TextDocumentSyncKind> = {
+  None: 0,
+  Full: 1,
+  Incremental: 2,
+};
+
+const DEFAULT_TEXT_DOCUMENT_SYNC: ResolvedTextDocumentSync = {
+  openClose: true,
+  change: TEXT_DOCUMENT_SYNC_KIND.Incremental,
+  willSave: false,
+  willSaveWaitUntil: false,
+};
+
+function resolveTextDocumentSync(sync: unknown): ResolvedTextDocumentSync {
+  const result: ResolvedTextDocumentSync = { ...DEFAULT_TEXT_DOCUMENT_SYNC };
+  if (typeof sync === 'number') {
+    if (sync === TEXT_DOCUMENT_SYNC_KIND.None) {
+      result.change = TEXT_DOCUMENT_SYNC_KIND.None;
+    } else if (sync === TEXT_DOCUMENT_SYNC_KIND.Full) {
+      result.change = TEXT_DOCUMENT_SYNC_KIND.Full;
+    } else {
+      result.change = TEXT_DOCUMENT_SYNC_KIND.Incremental;
+    }
+    return result;
+  }
+  if (!sync || typeof sync !== 'object') {
+    return result;
+  }
+  const options = sync as TextDocumentSyncOptions;
+  if (typeof options.openClose === 'boolean') {
+    result.openClose = options.openClose;
+  }
+  if (typeof options.change === 'number') {
+    if (options.change === TEXT_DOCUMENT_SYNC_KIND.None) {
+      result.change = TEXT_DOCUMENT_SYNC_KIND.None;
+    } else if (options.change === TEXT_DOCUMENT_SYNC_KIND.Full) {
+      result.change = TEXT_DOCUMENT_SYNC_KIND.Full;
+    } else {
+      result.change = TEXT_DOCUMENT_SYNC_KIND.Incremental;
+    }
+  }
+  if (typeof options.willSave === 'boolean') {
+    result.willSave = options.willSave;
+  }
+  if (typeof options.willSaveWaitUntil === 'boolean') {
+    result.willSaveWaitUntil = options.willSaveWaitUntil;
+  }
+  if (typeof options.save === 'boolean' || (options.save && typeof options.save === 'object')) {
+    result.save = options.save;
+  }
+  return result;
+}
+
 export function createTypeScriptAdapter(): LanguageAdapter {
   const serverEntry = resolveServerEntry();
 
@@ -41,6 +106,7 @@ export function createTypeScriptAdapter(): LanguageAdapter {
   let initializing: Promise<InitializationState> | null = null;
   let lastInitialization: InitializationState | null = null;
   const pendingNotifications: PendingNotification[] = [];
+  let textDocumentSync: ResolvedTextDocumentSync = { ...DEFAULT_TEXT_DOCUMENT_SYNC };
 
   const ensureConnection = () => {
     if (connection && child && !child.killed) {
@@ -71,6 +137,39 @@ export function createTypeScriptAdapter(): LanguageAdapter {
       }
 
       registrationContext.notifyClient(message.method, message.params ?? {});
+    });
+
+    connection.on('request', async (message) => {
+      const activeConnection = connection;
+      if (!registrationContext || !activeConnection || !message.method || message.id === undefined || message.id === null) {
+        return;
+      }
+      try {
+        if (message.method === 'workspace/applyEdit') {
+          const params = (message.params ?? {}) as { edit?: WorkspaceEdit };
+          if (!params || typeof params !== 'object' || typeof params.edit !== 'object') {
+            activeConnection.sendErrorResponse(message.id, new Error('Invalid workspace/applyEdit payload'));
+            return;
+          }
+          const result = registrationContext.applyWorkspaceEdit(params.edit as WorkspaceEdit);
+          const response: Record<string, unknown> = { applied: result.applied };
+          if (!result.applied) {
+            response.failureReason = result.failureReason ?? 'Workspace edit failed';
+            if (typeof result.failedChange === 'number') {
+              response.failedChange = result.failedChange;
+            }
+          }
+          activeConnection.sendResponse(message.id, response);
+          return;
+        }
+        const result = await registrationContext.handleServerRequest(
+          message.method,
+          message.params ?? {},
+        );
+        activeConnection.sendResponse(message.id, result ?? null);
+      } catch (error) {
+        activeConnection.sendErrorResponse(message.id, error);
+      }
     });
 
     connection.on('error', (error) => {
@@ -151,6 +250,9 @@ export function createTypeScriptAdapter(): LanguageAdapter {
           workspaceFolders: workspaceFolder ? [{ uri: rootUri, name: 'workspace' }] : [],
         });
 
+        const capabilities = (result as { capabilities?: { textDocumentSync?: unknown } } | null | undefined)?.capabilities;
+        textDocumentSync = resolveTextDocumentSync(capabilities?.textDocumentSync);
+
         conn.sendNotification('initialized', {});
         initialized = true;
         lastInitialization = { result, timestamp: Date.now() };
@@ -209,6 +311,7 @@ export function createTypeScriptAdapter(): LanguageAdapter {
     initialized = false;
     initializing = null;
     lastInitialization = null;
+    textDocumentSync = { ...DEFAULT_TEXT_DOCUMENT_SYNC };
 
     try {
       conn?.dispose();
@@ -263,14 +366,16 @@ export function createTypeScriptAdapter(): LanguageAdapter {
     },
     openDocument: (params: { uri: string; languageId: string; text: string; version: number }) => {
       ensureInitialized().catch(() => undefined);
-      sendNotification('textDocument/didOpen', {
-        textDocument: {
-          uri: params.uri,
-          languageId: params.languageId,
-          version: params.version,
-          text: params.text,
-        },
-      });
+      if (textDocumentSync.openClose !== false) {
+        sendNotification('textDocument/didOpen', {
+          textDocument: {
+            uri: params.uri,
+            languageId: params.languageId,
+            version: params.version,
+            text: params.text,
+          },
+        });
+      }
     },
     updateDocument: (params: {
       uri: string;
@@ -280,12 +385,20 @@ export function createTypeScriptAdapter(): LanguageAdapter {
       changes: DocumentChange[];
     }) => {
       ensureInitialized().catch(() => undefined);
-      const contentChanges = Array.isArray(params.changes) && params.changes.length > 0
-        ? params.changes.map((change) => ({
-            range: change.range,
-            text: change.text,
-          }))
-        : [{ text: params.text }];
+      if (textDocumentSync.change === TEXT_DOCUMENT_SYNC_KIND.None) {
+        return;
+      }
+      let contentChanges;
+      if (textDocumentSync.change === TEXT_DOCUMENT_SYNC_KIND.Full) {
+        contentChanges = [{ text: params.text }];
+      } else if (Array.isArray(params.changes) && params.changes.length > 0) {
+        contentChanges = params.changes.map((change) => ({
+          range: change.range,
+          text: change.text,
+        }));
+      } else {
+        contentChanges = [{ text: params.text }];
+      }
       sendNotification('textDocument/didChange', {
         textDocument: { uri: params.uri, version: params.version },
         contentChanges,
@@ -293,9 +406,11 @@ export function createTypeScriptAdapter(): LanguageAdapter {
     },
     closeDocument: (params: { uri: string }) => {
       ensureInitialized().catch(() => undefined);
-      sendNotification('textDocument/didClose', {
-        textDocument: { uri: params.uri },
-      });
+      if (textDocumentSync.openClose !== false) {
+        sendNotification('textDocument/didClose', {
+          textDocument: { uri: params.uri },
+        });
+      }
     },
     getCompletions: (params: unknown) => sendRequest('textDocument/completion', params),
     getHover: (params: unknown) => sendRequest('textDocument/hover', params),


### PR DESCRIPTION
## Summary
- handle JSON-RPC server initiated requests, surface error responses, and expose response helpers
- extend PolyClient workspace edit processing plus request routing for workspace/applyEdit et al, updating context APIs and documentation
- honor textDocumentSync capabilities in Go/TypeScript adapters and add coverage for documentChanges and server request integration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d52841b094833094d086a0bc181923

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add server-initiated JSON-RPC handling, LSP 3.17-compliant workspace edits (incl. documentChanges/rename with failure metadata), and textDocumentSync-driven doc sync in Go/TS adapters.
> 
> - **Core (`src/core/polyClient.ts`)**:
>   - Implement `applyWorkspaceEdit` supporting LSP 3.17 `documentChanges` (incl. rename) and return `failureReason`/`failedChange` on errors.
>   - Add server request routing via `handleServerRequest` for `workspace/applyEdit`, `workspace/configuration`, `window/showMessageRequest`, capability no-ops, and `workspace/workspaceFolders`.
>   - Expose `handleServerRequest` and `applyWorkspaceEdit` on `LanguageRegistrationContext`.
> - **Adapters (`src/adapters/{go,typescrip t}.ts`)**:
>   - Honor server `textDocumentSync` capabilities: conditional `didOpen`/`didClose`, and `didChange` in `Full`/`Incremental`/`None` modes.
>   - Handle server-initiated JSON-RPC requests: proxy `workspace/applyEdit` via context and generic requests via `handleServerRequest`; reply with `sendResponse`/`sendErrorResponse`.
>   - Reset sync state on shutdown.
> - **Utils (`src/utils/jsonRpc.ts`)**:
>   - Treat JSON-RPC `error` as rejected requests; emit `request` events; add `sendResponse`/`sendErrorResponse`; normalize error payloads.
> - **Types (`src/types.ts`)**:
>   - Add LSP 3.17 edit/annotation types, `TextDocumentSync{Kind,Options}`, `WorkspaceDocumentChange`, `ApplyWorkspaceEditResult`, and `HandleServerRequest`; extend `WorkspaceEdit`.
> - **Docs (`README.md`)**: Document server-initiated requests, error propagation, text sync behavior, and expanded `applyWorkspaceEdit`.
> - **Tests**: Add coverage for `documentChanges`, failure metadata, and server request handling; adjust assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffe25089b32a8d36578931f3bb88538722e09e4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->